### PR TITLE
Removed production sdk dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## [v0.13.1][v0.13.1] - ?
+
+- Removed symbol-sdk dependency.
+
 ## [v0.13.0][v0.13.0] - 29-Sep-2020
 
 - Upgraded symbol-sdk to v0.21.0

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ The software allows you to create the following QR types:
 ### Generate QRCode for a Transaction Request
 
 ```typescript
-import { QRCodeGenerator } from 'symbol-qr-library';
+import { QRCodeGenerator } from 'symbol-qr-library'; 
+import {Address, Deadline,Mosaic,NamespaceId,NetworkType,PlainMessage, TransferTransaction,UInt64} from "symbol-sdk";
 
 // (Optional) create transfer transaction (or read from network)
 const transfer = TransferTransaction.create(

--- a/examples/ExampleRequestTransactionQR.ts
+++ b/examples/ExampleRequestTransactionQR.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {
-    NetworkType,
+    NetworkType, TransactionMapping,
 } from 'symbol-sdk';
 
 // internal dependencies
@@ -58,7 +58,7 @@ class ExampleRequestTransactionQR extends Example {
 
         // create QR Code with JSON content
         const transactionQR = TransactionQR.fromJSON(
-            JSON.stringify(unsignedTransferInfo),
+            JSON.stringify(unsignedTransferInfo), TransactionMapping.createFromPayload,
         );
 
         console.log("TransactionQR JSON: ", transactionQR.toJSON());

--- a/index.ts
+++ b/index.ts
@@ -16,6 +16,9 @@
 
 import * as QRCodeSettings from './src/QRCodeSettings';
 
+
+export * from './src/sdk';
+
 // enumerations / interfaces
 export { QRCodeInterface } from './src/QRCodeInterface';
 export { QRCodeType } from './src/QRCodeType';

--- a/package-lock.json
+++ b/package-lock.json
@@ -3233,7 +3233,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3254,12 +3255,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3274,17 +3277,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3401,7 +3407,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3413,6 +3420,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3427,6 +3435,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3434,12 +3443,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3458,6 +3469,7 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -3519,7 +3531,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -3547,7 +3560,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3559,6 +3573,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3636,7 +3651,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3672,6 +3688,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3691,6 +3708,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3734,12 +3752,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-qr-library",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Symbol library to handle QR Codes",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,9 @@
     "braces": ">=2.3.1",
     "canvas": "^2.6.1",
     "crypto-js": "^3.3.0",
-    "symbol-hd-wallets": "0.13.0",
-    "symbol-sdk": "^0.21.0",
     "open": "^7.0.2",
-    "qrcode": "^1.4.4"
+    "qrcode": "^1.4.4",
+    "symbol-hd-wallets": "0.13.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.9",
@@ -34,6 +33,7 @@
     "mocha": "^5.2.0",
     "nyc": "^15.0.1",
     "rxjs": "^6.5.4",
+    "symbol-sdk": "^0.21.0",
     "ts-loader": "^6.2.1",
     "ts-node": "^7.0.0",
     "tslint": "^6.0.0",

--- a/src/AccountQR.ts
+++ b/src/AccountQR.ts
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    Account,
-    NetworkType,
-} from "symbol-sdk";
 
 // internal dependencies
 import {
@@ -26,22 +22,23 @@ import {
     QRCodeInterface,
     QRCodeType,
 } from '../index';
+import {INetworkType} from "./sdk/INetworkType";
 
 class AccountQR extends QRCode implements QRCodeInterface {
     /**
      * Construct an Account QR Code out of the
-     * symbol-sdk Account or PublicAccount instance.
+     * symbol private key.
      *
-     * @param   account         {Account}
+     * @param   accountPrivateKey  {string}
      * @param   password        {string}
-     * @param   networkType     {NetworkType}
+     * @param   networkType     {INetworkType}
      * @param   generationHash  {string}
      */
     constructor(/**
                  * The account to be exported
                  * @var {Account}
                  */
-                public readonly account: Account,
+                public readonly accountPrivateKey: string,
                 /**
                  * The password for encryption
                  * @var {string}
@@ -51,7 +48,7 @@ class AccountQR extends QRCode implements QRCodeInterface {
                  * The network type.
                  * @var {NetworkType}
                  */
-                public readonly networkType: NetworkType,
+                public readonly networkType: INetworkType,
                 /**
                  * The network generation hash.
                  * @var {string}

--- a/src/ContactQR.ts
+++ b/src/ContactQR.ts
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    Account,
-    NetworkType,
-    PublicAccount,
-} from 'symbol-sdk';
+
 
 // internal dependencies
 import {
@@ -27,14 +23,16 @@ import {
     QRCodeInterface,
     QRCodeType,
 } from '../index';
+import {INetworkType} from "./sdk/INetworkType";
 
 class ContactQR extends QRCode implements QRCodeInterface {
     /**
      * Construct a Contact QR Code out of the
-     * symbol-sdk Account or PublicAccount instance.
+     * symbol public key.
      *
-     * @param   account         {Account|PublicAccount}
-     * @param   networkType     {NetworkType}
+     * @param name the contact name.
+     * @param   accountPublicKey         the public key
+     * @param   networkType     {INetworkType}
      * @param   generationHash         {string}
      */
     constructor(/**
@@ -43,15 +41,14 @@ class ContactQR extends QRCode implements QRCodeInterface {
                  */
                 public readonly name: string,
                 /**
-                 * The contact account.
-                 * @var {Account|PublicAccount|Address}
+                 * The account public key.
                  */
-                public readonly account: Account | PublicAccount,
+                public readonly accountPublicKey:string,
                 /**
                  * The network type.
                  * @var {NetworkType}
                  */
-                public readonly networkType: NetworkType,
+                public readonly networkType: INetworkType,
                 /**
                  * The network generation hash.
                  * @var {string}

--- a/src/CosignatureQR.ts
+++ b/src/CosignatureQR.ts
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    AggregateTransaction,
-    NetworkType,
-} from 'symbol-sdk';
+
 
 // internal dependencies
 import {
@@ -26,13 +23,14 @@ import {
     RequestCosignatureDataSchema,
     TransactionQR,
 } from '../index';
+import {INetworkType, ITransaction} from "./sdk";
 
 class CosignatureQR extends TransactionQR implements QRCodeInterface {
     /**
      * Construct a Transaction Request QR Code out of the
      * symbol-sdk Transaction instance.
      *
-     * @param   transaction     {Transaction}
+     * @param   transaction     {ITransaction}
      * @param   networkType     {NetworkType}
      * @param   generationHash         {string}
      */
@@ -40,17 +38,17 @@ class CosignatureQR extends TransactionQR implements QRCodeInterface {
                  * The transaction for the request.
                  * @var {AggregateTransaction}
                  */
-                public readonly transaction: AggregateTransaction,
+                transaction: ITransaction,
                 /**
                  * The network type.
                  * @var {NetworkType}
                  */
-                public readonly networkType: NetworkType,
+                networkType: INetworkType,
                 /**
                  * The network generation hash.
                  * @var {string}
                  */
-                public readonly generationHash: string) {
+                generationHash: string) {
         super(transaction, networkType, generationHash, QRCodeType.RequestCosignature);
     }
 
@@ -59,6 +57,7 @@ class CosignatureQR extends TransactionQR implements QRCodeInterface {
      * object.
      *
      * @param   json        {string}
+     * @param   transactionCreateFromPayload the transaction parser that creates a transaction from a binary payload.
      * @return  {CosignatureQR}
      * @throws  {Error}     On empty `json` given.
      * @throws  {Error}     On missing `type` field value.
@@ -66,10 +65,11 @@ class CosignatureQR extends TransactionQR implements QRCodeInterface {
      */
     public static fromJSON(
         json: string,
+        transactionCreateFromPayload: (payload: string) => ITransaction,
     ): CosignatureQR {
 
         // create the QRCode object from JSON
-        return RequestCosignatureDataSchema.parse(json);
+        return RequestCosignatureDataSchema.parse(json, transactionCreateFromPayload);
     }
 
     /**

--- a/src/MnemonicQR.ts
+++ b/src/MnemonicQR.ts
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 import { MnemonicPassPhrase } from 'symbol-hd-wallets';
-import {
-    NetworkType,
-} from "symbol-sdk";
+
 
 // internal dependencies
 import {
@@ -26,6 +24,7 @@ import {
     QRCodeInterface,
     QRCodeType,
 } from '../index';
+import {INetworkType} from "./sdk/INetworkType";
 
 class MnemonicQR extends QRCode implements QRCodeInterface {
     /**
@@ -51,7 +50,7 @@ class MnemonicQR extends QRCode implements QRCodeInterface {
                  * The network type.
                  * @var {NetworkType}
                  */
-                public readonly networkType: NetworkType,
+                public readonly networkType: INetworkType,
                 /**
                  * The network generation hash.
                  * @var {string}

--- a/src/ObjectQR.ts
+++ b/src/ObjectQR.ts
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    NetworkType,
-} from "symbol-sdk";
 
 // internal dependencies
 import {
@@ -25,6 +22,7 @@ import {
     QRCodeInterface,
     QRCodeType,
 } from '../index';
+import {INetworkType} from "./sdk/INetworkType";
 
 class ObjectQR extends QRCode implements QRCodeInterface {
     /**
@@ -32,7 +30,7 @@ class ObjectQR extends QRCode implements QRCodeInterface {
      * JSON object.
      *
      * @param   object          {Object}
-     * @param   networkType     {NetworkType}
+     * @param   networkType     {INetworkType}
      * @param   generationHash         {string}
      */
     constructor(/**
@@ -44,7 +42,7 @@ class ObjectQR extends QRCode implements QRCodeInterface {
                  * The network type.
                  * @var {NetworkType}
                  */
-                public readonly networkType: NetworkType,
+                public readonly networkType: INetworkType,
                 /**
                  * The network generation hash.
                  * @var {string}

--- a/src/QRCode.ts
+++ b/src/QRCode.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { createCanvas } from 'canvas';
-import { NetworkType } from 'symbol-sdk';
 import * as QRCodeCanvas from 'qrcode';
 import {
     from as observableFrom,
@@ -30,6 +29,7 @@ import {
     QRCodeStreamType,
     QRCodeType,
 } from "../index";
+import {INetworkType} from "./sdk/INetworkType";
 
 abstract class QRCode implements QRCodeInterface {
 
@@ -49,7 +49,7 @@ abstract class QRCode implements QRCodeInterface {
                  * The network ID.
                  * @var {number}
                  */
-                public readonly networkType: NetworkType,
+                public readonly networkType: INetworkType,
                 /**
                  * The network generation hash.
                  * @var {string}

--- a/src/QRCodeGenerator.ts
+++ b/src/QRCodeGenerator.ts
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 import { MnemonicPassPhrase } from 'symbol-hd-wallets';
-import {
-    Account,
-    NetworkType,
-    PublicAccount,
-    Transaction,
-} from "symbol-sdk";
 
 // internal dependencies
 import {
@@ -32,6 +26,7 @@ import {
     QRCodeType,
     TransactionQR,
 } from '../index';
+import { INetworkType, ITransaction } from "./sdk";
 
 /**
  * Class `QRCodeGenerator` describes a NIP-7 compliant QR Code
@@ -58,8 +53,8 @@ class QRCodeGenerator {
      */
     public static createExportObject(
         object: object,
-        networkType: NetworkType = NetworkType.MIJIN_TEST,
-        generationHash: string = '17FA4747F5014B50413CCF968749604D728D7065DC504291EEE556899A534CBB',
+        networkType: INetworkType,
+        generationHash: string,
     ): ObjectQR {
         return new ObjectQR(object, networkType, generationHash);
     }
@@ -69,17 +64,18 @@ class QRCodeGenerator {
      * and account.
      *
      * @see {ContactQR}
-     * @param   transaction     {Transaction}
+     * @param   name the name
+     * @param   accountPublicKey     the account public key
      * @param   networkType     {NetworkType}
      * @param   generationHash         {string}
      */
     public static createAddContact(
         name: string,
-        account: Account | PublicAccount,
-        networkType: NetworkType = NetworkType.MIJIN_TEST,
-        generationHash: string = '17FA4747F5014B50413CCF968749604D728D7065DC504291EEE556899A534CBB',
+        accountPublicKey: string,
+        networkType: INetworkType,
+        generationHash: string,
     ): ContactQR {
-        return new ContactQR(name, account, networkType, generationHash);
+        return new ContactQR(name, accountPublicKey, networkType, generationHash);
     }
 
     /**
@@ -87,18 +83,18 @@ class QRCodeGenerator {
      * instance, encrypted with given password.
      *
      * @see {AccountQR}
-     * @param   account         {Account}
+     * @param   accountPrivateKey    the account private key.
      * @param   password        {string}
      * @param   networkType     {NetworkType}
      * @param   generationHash         {string}
      */
     public static createExportAccount(
-        account: Account,
+        accountPrivateKey: string,
         password: string,
-        networkType: NetworkType = NetworkType.MIJIN_TEST,
-        generationHash: string = '17FA4747F5014B50413CCF968749604D728D7065DC504291EEE556899A534CBB',
+        networkType: INetworkType,
+        generationHash: string,
     ): AccountQR {
-        return new AccountQR(account, password, networkType, generationHash);
+        return new AccountQR(accountPrivateKey, password, networkType, generationHash);
     }
 
     /**
@@ -111,9 +107,9 @@ class QRCodeGenerator {
      * @param   generationHash         {string}
      */
     public static createTransactionRequest(
-        transaction: Transaction,
-        networkType: NetworkType = NetworkType.MIJIN_TEST,
-        generationHash: string = '17FA4747F5014B50413CCF968749604D728D7065DC504291EEE556899A534CBB',
+        transaction: ITransaction,
+        networkType: INetworkType,
+        generationHash: string,
     ): TransactionQR {
         return new TransactionQR(transaction, networkType, generationHash);
     }
@@ -131,8 +127,8 @@ class QRCodeGenerator {
     public static createExportMnemonic(
         mnemonic: MnemonicPassPhrase,
         password: string,
-        networkType: NetworkType = NetworkType.MIJIN_TEST,
-        generationHash: string = '17FA4747F5014B50413CCF968749604D728D7065DC504291EEE556899A534CBB',
+        networkType: INetworkType,
+        generationHash: string,
     ): MnemonicQR {
         return new MnemonicQR(mnemonic, password, networkType, generationHash);
     }
@@ -142,6 +138,8 @@ class QRCodeGenerator {
      * of QRCode.
      *
      * @param   json    {string}
+     * @param   transactionCreateFromPayload the transaction factory to create ITransaction from a binary payload if the qr is a transaction based one.
+     * @param   password to decrypt private keys.
      * @return  {QRCode}
      * @throws  {Error}     On empty `json` given.
      * @throws  {Error}     On missing `type` field value.
@@ -149,6 +147,7 @@ class QRCodeGenerator {
      */
     public static fromJSON(
         json: string,
+        transactionCreateFromPayload: (payload: string) => ITransaction,
         password?: string,
     ): QRCode {
 
@@ -195,11 +194,11 @@ class QRCodeGenerator {
 
         // create a CosignatureQR from JSON
         case QRCodeType.RequestCosignature:
-            return CosignatureQR.fromJSON(json);
+            return CosignatureQR.fromJSON(json, transactionCreateFromPayload);
 
         // create a TransactionQR from JSON
         case QRCodeType.RequestTransaction:
-            return TransactionQR.fromJSON(json);
+            return TransactionQR.fromJSON(json, transactionCreateFromPayload);
 
         // create an MnemonicQR from JSON
         case QRCodeType.ExportMnemonic:

--- a/src/TransactionQR.ts
+++ b/src/TransactionQR.ts
@@ -13,19 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    NetworkType,
-    Transaction,
-} from "symbol-sdk";
 
 // internal dependencies
 import {
+    INetworkType,
     QRCode,
     QRCodeDataSchema,
     QRCodeInterface,
     QRCodeType,
     RequestTransactionDataSchema,
 } from '../index';
+import {ITransaction} from "./sdk";
 
 class TransactionQR extends QRCode implements QRCodeInterface {
     /**
@@ -40,12 +38,12 @@ class TransactionQR extends QRCode implements QRCodeInterface {
                  * The transaction for the request.
                  * @var {Transaction}
                  */
-                public readonly transaction: Transaction,
+                public readonly transaction: ITransaction,
                 /**
                  * The network type.
                  * @var {NetworkType}
                  */
-                public readonly networkType: NetworkType,
+                public readonly networkType: INetworkType,
                 /**
                  * The chain Id.
                  * @var {string}
@@ -65,6 +63,7 @@ class TransactionQR extends QRCode implements QRCodeInterface {
      * object.
      *
      * @param   json        {string}
+     * @param   transactionCreateFromPayload the transaction parser that creates a transaction from a binary payload.
      * @return  {TransactionQR}
      * @throws  {Error}     On empty `json` given.
      * @throws  {Error}     On missing `type` field value.
@@ -72,10 +71,11 @@ class TransactionQR extends QRCode implements QRCodeInterface {
      */
     public static fromJSON(
         json: string,
+        transactionCreateFromPayload: (payload: string) => ITransaction,
     ): TransactionQR {
 
         // create the QRCode object from JSON
-        return RequestTransactionDataSchema.parse(json);
+        return RequestTransactionDataSchema.parse(json, transactionCreateFromPayload);
     }
 
     /**

--- a/src/schemas/AddContactDataSchema.ts
+++ b/src/schemas/AddContactDataSchema.ts
@@ -13,9 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    PublicAccount,
-} from "symbol-sdk";
 
 // internal dependencies
 import {
@@ -46,7 +43,7 @@ class AddContactDataSchema extends QRCodeDataSchema {
     public getData(qr: ContactQR): any {
         return {
             "name": qr.name,
-            "publicKey": qr.account.publicKey.toString(),
+            "publicKey": qr.accountPublicKey,
         };
     }
 
@@ -75,10 +72,9 @@ class AddContactDataSchema extends QRCodeDataSchema {
         // read contact data
         const name = jsonObj.data.name;
         const network = jsonObj.network_id;
-        const account = PublicAccount.createFromPublicKey(jsonObj.data.publicKey, network);
         const generationHash = jsonObj.chain_id;
 
-        return new ContactQR(name, account, network, generationHash);
+        return new ContactQR(name, jsonObj.data.publicKey, network, generationHash);
     }
 }
 

--- a/src/schemas/ExportAccountDataSchema.ts
+++ b/src/schemas/ExportAccountDataSchema.ts
@@ -13,10 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    Account,
-    Password,
-} from "symbol-sdk";
 
 // internal dependencies
 import {
@@ -49,7 +45,7 @@ class ExportAccountDataSchema extends QRCodeDataSchema {
     public getData(qr: AccountQR): any {
 
         // we will store a password encrypted copy of the private key
-        const encrypted = EncryptionService.encrypt(qr.account.privateKey, qr.password);
+        const encrypted = EncryptionService.encrypt(qr.accountPrivateKey, qr.password);
 
         return {
             "ciphertext": encrypted.ciphertext,
@@ -102,8 +98,7 @@ class ExportAccountDataSchema extends QRCodeDataSchema {
             const generationHash = jsonObj.chain_id;
 
             // create account
-            const account = Account.createFromPrivateKey(privKey, network);
-            return new AccountQR(account, password, network, generationHash);
+            return new AccountQR(privKey, password, network, generationHash);
         }
         catch (e) {
             throw new Error('Could not parse encrypted account information.');

--- a/src/schemas/ExportMnemonicDataSchema.ts
+++ b/src/schemas/ExportMnemonicDataSchema.ts
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 import { MnemonicPassPhrase } from 'symbol-hd-wallets';
-import {
-    Password,
-} from "symbol-sdk";
 
 // internal dependencies
 import {

--- a/src/schemas/RequestCosignatureDataSchema.ts
+++ b/src/schemas/RequestCosignatureDataSchema.ts
@@ -13,14 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    AggregateTransaction,
-    TransactionMapping,
-} from "symbol-sdk";
 
 // internal dependencies
 import {
-    CosignatureQR,
+    CosignatureQR, ITransaction,
     QRCodeType,
     RequestTransactionDataSchema,
 } from '../../index';
@@ -42,6 +38,7 @@ class RequestCosignatureDataSchema extends RequestTransactionDataSchema {
      * object.
      *
      * @param   json    {string}
+     * @param   transactionCreateFromPayload the transaction parser that creates a transaction from a binary payload.
      * @return  {CosignatureQR}
      * @throws  {Error}     On empty `json` given.
      * @throws  {Error}     On missing `type` field value.
@@ -49,6 +46,7 @@ class RequestCosignatureDataSchema extends RequestTransactionDataSchema {
      */
     public static parse(
         json: string,
+        transactionCreateFromPayload: (payload: string) => ITransaction
     ): CosignatureQR {
         if (! json.length) {
             throw Error('JSON argument cannot be empty.');
@@ -60,11 +58,11 @@ class RequestCosignatureDataSchema extends RequestTransactionDataSchema {
         }
 
         // read contact data
-        const transaction = TransactionMapping.createFromPayload(jsonObj.data.payload);
+        const transaction = transactionCreateFromPayload(jsonObj.data.payload);
         const network = jsonObj.network_id;
         const generationHash = jsonObj.chain_id;
 
-        return new CosignatureQR(transaction as AggregateTransaction, network, generationHash);
+        return new CosignatureQR(transaction, network, generationHash);
     }
 }
 

--- a/src/schemas/RequestTransactionDataSchema.ts
+++ b/src/schemas/RequestTransactionDataSchema.ts
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    TransactionMapping,
-} from "symbol-sdk";
 
 // internal dependencies
 import {
+    ITransaction,
     QRCodeDataSchema,
     QRCodeType,
     TransactionQR,
@@ -58,6 +56,7 @@ class RequestTransactionDataSchema extends QRCodeDataSchema {
      * object.
      *
      * @param   json    {string}
+     * @param   transactionCreateFromPayload the transaction parser that creates a transaction from a binary payload.
      * @return  {TransactionQR}
      * @throws  {Error}     On empty `json` given.
      * @throws  {Error}     On missing `type` field value.
@@ -65,6 +64,7 @@ class RequestTransactionDataSchema extends QRCodeDataSchema {
      */
     public static parse(
         json: string,
+        transactionCreateFromPayload: (payload: string) => ITransaction
     ): TransactionQR {
         if (! json.length) {
             throw Error('JSON argument cannot be empty.');
@@ -76,7 +76,7 @@ class RequestTransactionDataSchema extends QRCodeDataSchema {
         }
 
         // read contact data
-        const transaction = TransactionMapping.createFromPayload(jsonObj.data.payload);
+        const transaction = transactionCreateFromPayload(jsonObj.data.payload);
         const network = jsonObj.network_id;
         const generationHash = jsonObj.chain_id;
 

--- a/src/sdk/INetworkType.ts
+++ b/src/sdk/INetworkType.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An alias of the symbol's network type.
+ */
+export type INetworkType = number

--- a/src/sdk/ITransaction.ts
+++ b/src/sdk/ITransaction.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An abstraction of the sdk's transaction object to avoid the dependency.
+ */
+export interface ITransaction {
+    /**
+     * It returns the catbuffer binary hex of the transaction.
+     */
+    serialize(): string;
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { INetworkType } from './INetworkType';
+export { ITransaction } from './ITransaction';
+

--- a/test/AccountQR.spec.ts
+++ b/test/AccountQR.spec.ts
@@ -38,7 +38,7 @@ describe('AccountQR -->', () => {
             );
 
             // Act:
-            const exportAccount = new AccountQR(account, 'password', NetworkType.MIJIN_TEST, 'no-chain-id');
+            const exportAccount = new AccountQR(account.privateKey, 'password', NetworkType.MIJIN_TEST, 'no-chain-id');
             const actualJSON = exportAccount.toJSON();
             const actualObject = JSON.parse(actualJSON);
 
@@ -58,7 +58,7 @@ describe('AccountQR -->', () => {
             );
 
             // Act:
-            const exportAccount = new AccountQR(account, 'password', NetworkType.MIJIN_TEST, 'no-chain-id');
+            const exportAccount = new AccountQR(account.privateKey, 'password', NetworkType.MIJIN_TEST, 'no-chain-id');
             const actualJSON = exportAccount.toJSON();
             const actualObject = JSON.parse(actualJSON);
 
@@ -70,15 +70,16 @@ describe('AccountQR -->', () => {
 
     describe('fromJSON() should', () => {
 
+        const networkType = NetworkType.MIJIN_TEST;
         it('throw error given wrong password', () => {
             // Arrange:
             const account = Account.createFromPrivateKey(
                 'F97AE23C2A28ECEDE6F8D6C447C0A10B55C92DDE9316CCD36C3177B073906978',
-                NetworkType.MIJIN_TEST,
+                networkType,
             );
 
             // Act:
-            const exportAccount = new AccountQR(account, 'password', NetworkType.MIJIN_TEST, 'no-chain-id');
+            const exportAccount = new AccountQR(account.privateKey, 'password', networkType, 'no-chain-id');
 
             // Act + Assert
             expect((() => {
@@ -91,7 +92,7 @@ describe('AccountQR -->', () => {
             const accountInfo: any = {
                 v: 3,
                 type: QRCodeType.ExportAccount,
-                network_id: NetworkType.MIJIN_TEST,
+                network_id: networkType,
                 chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
                 data: {
                     // 'ciphertext' field for encrypted payload missing
@@ -109,16 +110,15 @@ describe('AccountQR -->', () => {
             // Arrange:
             const account = Account.createFromPrivateKey(
                 'F97AE23C2A28ECEDE6F8D6C447C0A10B55C92DDE9316CCD36C3177B073906978',
-                NetworkType.MIJIN_TEST,
+                networkType,
             );
 
             // Act:
-            const exportAccount = new AccountQR(account, 'password', NetworkType.MIJIN_TEST, 'no-chain-id');
+            const exportAccount = new AccountQR(account.privateKey, 'password', networkType, 'no-chain-id');
             const importAccount = AccountQR.fromJSON(exportAccount.toJSON(), 'password');
 
             // Assert
-            expect(importAccount.account.privateKey).to.be.equal(exportAccount.account.privateKey);
-            expect(importAccount.account.publicKey).to.be.equal(exportAccount.account.publicKey);
+            expect(importAccount.accountPrivateKey).to.be.equal(exportAccount.accountPrivateKey);
         });
 
         it('reconstruct account given correct ciphertext and password', () => {
@@ -126,7 +126,7 @@ describe('AccountQR -->', () => {
             const accountInfo = {
                 v: 3,
                 type: QRCodeType.ExportAccount,
-                network_id: NetworkType.MIJIN_TEST,
+                network_id: networkType,
                 chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
                 data: {
                     ciphertext: '56d310848ee93d0794eb1f64a5195778ded2q7IxvtPbO+sA7jZZyhpu/khbaNdx1pzuoGoPJRw1A4aBsWPlex3y/gy5da8WjF0i4d+/D0B5ESy+zX5P+AoFAw3EFi3UVBdnav4rnqg=',
@@ -138,8 +138,8 @@ describe('AccountQR -->', () => {
             const importAccount = AccountQR.fromJSON(JSON.stringify(accountInfo), 'password');
 
             // Assert
-            expect(importAccount.account.privateKey).to.be.equal('749F1FF1972CD465CAB74566FF0AA021F846FBE3916ABB6A6C1373E962C76331');
-            expect(importAccount.account.publicKey).to.be.equal('50BFEB16AA0A3E00B8AB9385A2686991A09522DCDA4AC31B400BB5674EE4CDF8');
+            expect(importAccount.accountPrivateKey).to.be.equal('749F1FF1972CD465CAB74566FF0AA021F846FBE3916ABB6A6C1373E962C76331');
+            expect(Account.createFromPrivateKey(importAccount.accountPrivateKey, networkType).publicKey).to.be.equal('50BFEB16AA0A3E00B8AB9385A2686991A09522DCDA4AC31B400BB5674EE4CDF8');
         });
     });
 

--- a/test/ContactQR.spec.ts
+++ b/test/ContactQR.spec.ts
@@ -38,7 +38,7 @@ describe('ContactQR -->', () => {
             );
 
             // Act:
-            const addContact = new ContactQR(name, account, NetworkType.TEST_NET, '');
+            const addContact = new ContactQR(name, account.publicKey, NetworkType.TEST_NET, '');
             const actualJSON = addContact.toJSON();
             const actualObject = JSON.parse(actualJSON);
 
@@ -59,7 +59,7 @@ describe('ContactQR -->', () => {
             );
 
             // Act:
-            const addContact = new ContactQR(name, account, NetworkType.TEST_NET, '');
+            const addContact = new ContactQR(name, account.publicKey, NetworkType.TEST_NET, '');
             const actualJSON = addContact.toJSON();
             const actualObject = JSON.parse(actualJSON);
 
@@ -79,12 +79,12 @@ describe('ContactQR -->', () => {
             );
 
             // Act:
-            const exportContact = new ContactQR('nemtech', account, NetworkType.MIJIN_TEST, 'no-chain-id');
+            const exportContact = new ContactQR('nemtech', account.publicKey, NetworkType.MIJIN_TEST, 'no-chain-id');
             const importContact = ContactQR.fromJSON(exportContact.toJSON());
 
             // Assert
             expect(importContact.name).to.be.equal('nemtech');
-            expect(importContact.account.publicKey).to.be.equal(exportContact.account.publicKey);
+            expect(importContact.accountPublicKey).to.be.equal(exportContact.accountPublicKey);
         });
 
         it('reconstruct contact given correct JSON structure', () => {
@@ -105,7 +105,7 @@ describe('ContactQR -->', () => {
 
             // Assert
             expect(importContact.name).to.be.equal('nemtech');
-            expect(importContact.account.publicKey).to.be.equal('C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268');
+            expect(importContact.accountPublicKey).to.be.equal('C5C55181284607954E56CD46DE85F4F3EF4CC713CC2B95000FA741998558D268');
         });
 
     });

--- a/test/CosignatureQR.spec.ts
+++ b/test/CosignatureQR.spec.ts
@@ -22,14 +22,14 @@ import {
     NamespaceId,
     NetworkType,
     PlainMessage,
-    PublicAccount,
+    PublicAccount, TransactionMapping,
     TransferTransaction,
     UInt64,
 } from 'symbol-sdk';
 
 // internal dependencies
 import {
-    CosignatureQR,
+    CosignatureQR, ITransaction,
     QRCodeType,
 } from "../index";
 
@@ -100,7 +100,7 @@ describe('CosignatureQR -->', () => {
 
             // Act:
             const exportCosig = new CosignatureQR(bonded, NetworkType.MIJIN_TEST, 'no-chain-id');
-            const importCosig = CosignatureQR.fromJSON(exportCosig.toJSON());
+            const importCosig = CosignatureQR.fromJSON(exportCosig.toJSON(), TransactionMapping.createFromPayload);
 
             // Assert
             expect(importCosig.transaction.serialize()).to.be.equal(exportCosig.transaction.serialize());
@@ -126,7 +126,7 @@ describe('CosignatureQR -->', () => {
             };
 
             // Act:
-            const importCosig = CosignatureQR.fromJSON(JSON.stringify(cosigInfo));
+            const importCosig = CosignatureQR.fromJSON(JSON.stringify(cosigInfo), TransactionMapping.createFromPayload);
 
             // Assert:
             expect(importCosig.transaction.serialize()).to.be.equal(cosigInfo.data.payload);


### PR DESCRIPTION
Removed SDK prod dependency. It's only used for test.
Removed default generation hash and network type params. These default values may confuse the clients.
Fixes https://github.com/nemtech/symbol-qr-library/issues/41

This PR depends on https://github.com/nemtech/symbol-hd-wallets/pull/37. Once that one is merged, we can upgrade the dependency to SDK agnostic symbol-hd-wallets.

One alternative is to remove the `symbol-hd-wallets` dependency from this project. We can migrate MnemonicQR to work and encrypt the plain phrase. Clients can generate the Mnemonic object from/to the plain text. Actually, MnemonicQR could be converted to an "EncryptedTextQR" that holds any encrypted text, it just happens that the mnemonic phrase would be used.

@evias @rg911, what do you think? Should we make the QR lib even smaller by removing both sdk and symbol-hd-wallets dependency? I got the code to remove the symbol-hd-wallets dependency, it could happen in this PR or in another PR in the future.
