### PR TITLE
Address QR feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This is a PoC to validate the proposed [NIP 7 QR Library Standard Definition](ht
 The software allows you to create the following QR types:
 
 * **TransactionRequest**: QR to prepare transactions ready to be signed.
-* **Contact**: QR to share the account address with others.
+* **Address**: QR to share the account address with others.
+* **Contact**: QR to share the account address and public key with others.
 * **Mnemonic**: QR to generate account mnemonic backups (encrypted | plain).
 * **Account**: QR to generate account private key backups (encrypted | plain).
 * **Object**: QR to export  a custom object.
@@ -54,6 +55,25 @@ const generationHash = 'ACECD90E7B248E012803228ADB4424F0D966D24149B72E58987D2BF2
 
 // create QR Code base64
 const qrCode: TransactionQR = QRCodeGenerator.createTransactionRequest(transfer, NetworkType.MIJIN_TEST, generationHash);
+
+// get base64 notation for <img> HTML attribute
+const base64 = qrCode.toBase64();
+```
+
+### Generate AddressQR code
+
+```typescript
+import { QRCodeGenerator, AddressQR } from 'symbol-qr-library';
+import { NetworkType } from 'symbol-sdk';
+
+const name = 'test-address-1';
+const contactAddress = 'TA6QZTYPOIYQYR5NRY4WQ2WRQUX2FN5UK2DO6DI'
+
+// generation hash of the connected network
+const generationHash = 'ACECD90E7B248E012803228ADB4424F0D966D24149B72E58987D2BF2F2AF03C4'
+
+// create QR Code base64
+const qrCode: AddressQR = QRCodeGenerator.createExportAddress(name, contactAddress, NetworkType.TEST_NET, generationHash);
 
 // get base64 notation for <img> HTML attribute
 const base64 = qrCode.toBase64();

--- a/index.ts
+++ b/index.ts
@@ -44,6 +44,7 @@ export { EncryptionService } from './src/services/EncryptionService';
 // specialized QR Code classes
 export { AccountQR } from './src/AccountQR';
 export { ContactQR } from './src/ContactQR';
+export { AddressQR } from './src/AddressQR';
 export { ObjectQR } from './src/ObjectQR';
 export { TransactionQR } from './src/TransactionQR';
 export { CosignatureQR } from './src/CosignatureQR';

--- a/src/AddressQR.ts
+++ b/src/AddressQR.ts
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+// internal dependencies
+import {
+    QRCode,
+    QRCodeDataSchema,
+    QRCodeInterface,
+    QRCodeType,
+} from '../index';
+import {INetworkType} from "./sdk/INetworkType";
+import {ExportAddressDataSchema} from "./schemas/ExportAddressDataSchema";
+
+class AddressQR extends QRCode implements QRCodeInterface {
+    /**
+     * Construct a Address QR Code out of the
+     * symbol public key.
+     *
+     * @param name the address name.
+     * @param   accountPublicKey         the public key
+     * @param   networkType     {INetworkType}
+     * @param   generationHash         {string}
+     */
+    constructor(/**
+                 * The address name.
+                 * @var {string}
+                 */
+                public readonly name: string,
+                /**
+                 * The account address.
+                 */
+                public readonly accountAddress:string,
+                /**
+                 * The network type.
+                 * @var {NetworkType}
+                 */
+                public readonly networkType: INetworkType,
+                /**
+                 * The network generation hash.
+                 * @var {string}
+                 */
+                public readonly generationHash: string) {
+        super(QRCodeType.ExportAddress, networkType, generationHash);
+    }
+
+    /**
+     * Parse a JSON QR code content into an AddressQR
+     * object.
+     *
+     * @param   json        {string}
+     * @return  {AddressQR}
+     * @throws  {Error}     On empty `json` given.
+     * @throws  {Error}     On missing `type` field value.
+     * @throws  {Error}     On unrecognized QR code `type` field value.
+     */
+    public static fromJSON(
+        json: string,
+    ): AddressQR {
+
+        // create the QRCode object from JSON
+        return ExportAddressDataSchema.parse(json);
+    }
+
+    /**
+     * The `getTypeNumber()` method should return the
+     * version number for QR codes of the underlying class.
+     *
+     * @see https://en.wikipedia.org/wiki/QR_code#Storage
+     * @return {number}
+     */
+    public getTypeNumber(): number {
+        // Type version for AddressQR is Version 15, uses correction level M
+        // This type of QR can hold up to 412 binary bytes.
+        return 15;
+    }
+
+    /**
+     * The `getSchema()` method should return an instance
+     * of a sub-class of QRCodeDataSchema which describes
+     * the QR Code data.
+     *
+     * @return {QRCodeDataSchema}
+     */
+    public getSchema(): QRCodeDataSchema {
+        return new ExportAddressDataSchema();
+    }
+}
+
+export {AddressQR};

--- a/src/QRCodeGenerator.ts
+++ b/src/QRCodeGenerator.ts
@@ -17,6 +17,7 @@
 // internal dependencies
 import {
     AccountQR,
+    AddressQR,
     ContactQR,
     CosignatureQR,
     MnemonicQR,
@@ -56,6 +57,25 @@ class QRCodeGenerator {
         generationHash: string,
     ): ObjectQR {
         return new ObjectQR(object, networkType, generationHash);
+    }
+
+    /**
+     * Create an Address QR Code from a contact name
+     * and address.
+     *
+     * @see {AddressQR}
+     * @param   name the name
+     * @param   address     the account address
+     * @param   networkType     {NetworkType}
+     * @param   generationHash         {string}
+     */
+    public static createExportAddress(
+        name: string,
+        address: string,
+        networkType: INetworkType,
+        generationHash: string,
+    ): AddressQR {
+        return new AddressQR(name, address, networkType, generationHash);
     }
 
     /**
@@ -175,6 +195,10 @@ class QRCodeGenerator {
             // create a ContactQR from JSON
             case QRCodeType.AddContact:
                 return ContactQR.fromJSON(json);
+
+            // create a AddressQR from JSON
+            case QRCodeType.ExportAddress:
+                return AddressQR.fromJSON(json);
 
             // create an AccountQR from JSON
             case QRCodeType.ExportAccount:

--- a/src/QRCodeType.ts
+++ b/src/QRCodeType.ts
@@ -20,6 +20,7 @@ enum QRCodeType {
     RequestCosignature = 4,
     ExportMnemonic = 5,
     ExportObject = 6,
+    ExportAddress = 7,
 }
 
 export {QRCodeType};

--- a/src/schemas/ExportAddressDataSchema.ts
+++ b/src/schemas/ExportAddressDataSchema.ts
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// internal dependencies
+import {
+    QRCodeDataSchema,
+    QRCodeType,
+} from '../../index';
+import {AddressQR} from "../AddressQR";
+
+/**
+ * Class `ExportAddressDataSchema` describes a contact
+ * add QR code data schema.
+ *
+ * @since 0.3.0
+ */
+class ExportAddressDataSchema extends QRCodeDataSchema {
+
+    constructor() {
+        super();
+    }
+
+    /**
+     * The `getData()` method returns an object
+     * that will be stored in the `data` field of
+     * the underlying QR Code JSON content.
+     *
+     * @return {any}
+     */
+    public getData(qr: AddressQR): any {
+        return {
+            "name": qr.name,
+            "address": qr.accountAddress,
+        };
+    }
+
+    /**
+     * Parse a JSON QR code content into a ContactQR
+     * object.
+     *
+     * @param   json    {string}
+     * @return  {AddressQR}
+     * @throws  {Error}     On empty `json` given.
+     * @throws  {Error}     On missing `type` field value.
+     * @throws  {Error}     On unrecognized QR code `type` field value.
+     */
+    public static parse(
+        json: string,
+    ): AddressQR {
+        if (! json.length) {
+            throw Error('JSON argument cannot be empty.');
+        }
+
+        const jsonObj = JSON.parse(json);
+        if (!jsonObj.type ||jsonObj.type !== QRCodeType.ExportAddress) {
+            throw Error('Invalid type field value for AddressQR.');
+        }
+
+        // read contact data
+        const name = jsonObj.data.name;
+        const network = jsonObj.network_id;
+        const generationHash = jsonObj.chain_id;
+
+        return new AddressQR(name, jsonObj.data.address, network, generationHash);
+    }
+}
+
+export {ExportAddressDataSchema};

--- a/test/AddressQR.spec.ts
+++ b/test/AddressQR.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {expect} from "chai";
+import {
+    Address,
+    NetworkType,
+} from 'symbol-sdk';
+
+// internal dependencies
+import {
+    AddressQR,
+    QRCodeType,
+} from "../index";
+
+describe('AccountQR -->', () => {
+
+    describe('toJSON() should', () => {
+
+        it('include mandatory NIP-7 QR Code base fields', () => {
+            // Arrange:
+            const name = 'test-contact-1';
+            const address = Address.createFromRawAddress('TA6QZTYPOIYQYR5NRY4WQ2WRQUX2FN5UK2DO6DI');
+
+            // Act:
+            const addressQR = new AddressQR(name, address.plain(), NetworkType.TEST_NET, '');
+            const actualJSON = addressQR.toJSON();
+            const actualObject = JSON.parse(actualJSON);
+
+            // Assert:
+            expect(actualObject).to.have.property('v');
+            expect(actualObject).to.have.property('type');
+            expect(actualObject).to.have.property('network_id');
+            expect(actualObject).to.have.property('chain_id');
+            expect(actualObject).to.have.property('data');
+        });
+
+        it('include specialized schema fields', () => {
+            // Arrange:
+            const name = 'test-address-1';
+            const address = Address.createFromRawAddress('TA6QZTYPOIYQYR5NRY4WQ2WRQUX2FN5UK2DO6DI');
+
+            // Act:
+            const addressQR = new AddressQR(name, address.plain(), NetworkType.TEST_NET, '');
+            const actualJSON = addressQR.toJSON();
+            const actualObject = JSON.parse(actualJSON);
+
+            // Assert:
+            expect(actualObject.data).to.have.property('name');
+            expect(actualObject.data).to.have.property('address');
+        });
+    });
+
+    describe('fromJSON() should', () => {
+
+        it('reconstruct contact given AddressQR JSON', () => {
+            // Arrange:
+            const address = Address.createFromRawAddress('TA6QZTYPOIYQYR5NRY4WQ2WRQUX2FN5UK2DO6DI');
+
+            // Act:
+            const exportContact = new AddressQR('nemtech', address.plain(), NetworkType.TEST_NET, 'no-chain-id');
+            const importContact = AddressQR.fromJSON(exportContact.toJSON());
+
+            // Assert
+            expect(importContact.name).to.be.equal('nemtech');
+            expect(importContact.accountAddress).to.be.equal(exportContact.accountAddress);
+        });
+
+        it('reconstruct contact given correct JSON structure', () => {
+            // Arrange:
+            const addressInfo = {
+                v: 3,
+                type: QRCodeType.ExportAddress,
+                network_id: NetworkType.TEST_NET,
+                chain_id: '9F1979BEBA29C47E59B40393ABB516801A353CFC0C18BC241FEDE41939C907E7',
+                data: {
+                    name: 'nemtech',
+                    address: 'TA6QZTYPOIYQYR5NRY4WQ2WRQUX2FN5UK2DO6DI',
+                },
+            };
+
+            // Act:
+            const addressQR = AddressQR.fromJSON(JSON.stringify(addressInfo));
+
+            // Assert
+            expect(addressQR.name).to.be.equal('nemtech');
+            expect(addressQR.accountAddress).to.be.equal('TA6QZTYPOIYQYR5NRY4WQ2WRQUX2FN5UK2DO6DI');
+        });
+
+    });
+
+});


### PR DESCRIPTION
Added support for Address QR codes.

AddressQR codes are needed to share virgin accounts that still don't have a public key announced to the network.