### PR TITLE
Account QR with unencrypted password fix

### DIFF
--- a/src/schemas/ExportAccountDataSchema.ts
+++ b/src/schemas/ExportAccountDataSchema.ts
@@ -88,7 +88,7 @@ class ExportAccountDataSchema extends QRCodeDataSchema {
 
         try {
             // decrypt private key
-            const privKey = EncryptedPayload.isDataEncrypted(jsonObj.data) ? EncryptionService.decrypt(EncryptedPayload.fromJSON(JSON.stringify(jsonObj.data)), password) : JSON.stringify(jsonObj.data);
+            const privKey = EncryptedPayload.isDataEncrypted(jsonObj.data) ? EncryptionService.decrypt(EncryptedPayload.fromJSON(JSON.stringify(jsonObj.data)), password) : jsonObj.data.privateKey;
 
             // more content validation
             if (!privKey || (privKey.length !== 64 && privKey.length !== 66)) {

--- a/test/AccountQR.spec.ts
+++ b/test/AccountQR.spec.ts
@@ -198,8 +198,8 @@ describe('AccountQR -->', () => {
                 );
 
                 // Act:
-                const exportAccount = new AccountQR(account.privateKey, networkType, 'no-chain-id', 'password');
-                const importAccount = AccountQR.fromJSON(exportAccount.toJSON(), 'password');
+                const exportAccount = new AccountQR(account.privateKey, networkType, 'no-chain-id');
+                const importAccount = AccountQR.fromJSON(exportAccount.toJSON());
 
                 // Assert
                 expect(importAccount.accountPrivateKey).to.be.equal(exportAccount.accountPrivateKey);


### PR DESCRIPTION
There was a bug with the function AccountQR.fromJSON() which was breaking the unencrypted account QRs. Tests had also a mistake which made this bug invisible